### PR TITLE
Fix name and link of book of Maaret Pyhäjärvi

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ Books
 
 - [Code with the Wisdom of the Crowd by Mark Pearl](https://pragprog.com/book/mpmob/code-with-the-wisdom-of-the-crowd)
 - [Mob Programming by Woody Zuill and Kevin Meadows](https://leanpub.com/mobprogramming)
-- [Mob Programming Guidebook by Maaret Pyhäjärvi](https://leanpub.com/mobprogrammingguidebook)
+- [Ensemble Programming Guidebook by Maaret Pyhäjärvi](https://leanpub.com/ensembleprogramming)
 - [Debugging Teams by Brian Fitzpatrick and Ben Collins-Sussman](http://shop.oreilly.com/product/0636920042372.do)
 
 Articles


### PR DESCRIPTION
Seems like the book was renamed.

See the quote from https://leanpub.com/ensembleprogramming :
"And in case you wondered about it: ensemble programming is the community rebrand of mob programming to more inclusive language. Since 2020, ensemble programming communities globally have adopted it as a synonym to the software development technique that centers kindness, consideration and respect so that we can bring a diverse group together to create software and have a true bias to action, over worrying about the negative connotations."